### PR TITLE
Add weekly PNL API and service implementation

### DIFF
--- a/Controllers/AccountController.cs
+++ b/Controllers/AccountController.cs
@@ -438,6 +438,54 @@ namespace BinanceDashboardAPI.Controllers
             }
         }
 
+        [HttpGet("GetWeeklyPNL")]
+        public async Task<IActionResult> GetWeeklyPNL()
+        {
+            try
+            {
+                var cts = new CancellationTokenSource(TimeSpan.FromSeconds(_apiSettings.TimeoutSeconds));
+                var response = await _binanceService.GetWeeklyPNLAsync().WaitAsync(cts.Token);
+                if (response is null)
+                {
+                    return NotFound(new ErrorResponse
+                    {
+                        Message = "Weekly PNL not found.",
+                        Error = "Weekly PNL information could not be retrieved."
+                    });
+                }
+                return Ok(response);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new ErrorResponse
+                {
+                    Message = "Invalid request.",
+                    Error = ex.Message
+                });
+            }
+            catch (TaskCanceledException)
+            {
+                ErrorResponse errorResponse = new ErrorResponse()
+                {
+                    Message = "The request timed out.",
+                    Error = "The service took too long to respond."
+                };
+                var result = new ObjectResult(errorResponse);
+                result.StatusCode = 504;
+                return result;
+            }
+            catch (Exception ex)
+            {
+                ErrorResponse errorResponse = new ErrorResponse()
+                {
+                    Message = "An error occurred while retrieving Weekly PNL.",
+                    Error = ex.Message
+                };
+                var result = new ObjectResult(errorResponse);
+                result.StatusCode = 500;
+                return result;
+            }
+        }
 
         [HttpGet("GetMonthlySummary")]
         public async Task<IActionResult> GetMonthlySummary()

--- a/Interfaces/Services/IBinanceService.cs
+++ b/Interfaces/Services/IBinanceService.cs
@@ -25,6 +25,8 @@ namespace Interfaces.Services
 
         Task<List<DailyPNLResponseDTO>> GetDailyPNLAsync();
 
+        Task<List<WeeklyPNLResponseDTO>> GetWeeklyPNLAsync();
+
         Task<List<MonthlySummaryResponseDto>> GetMonthlySummaryAsync();
 
         Task<List<HistoryResponseDto>> GetHistoryAsync();

--- a/Models/DTOs/WeeklyPNLResponseDTO.cs
+++ b/Models/DTOs/WeeklyPNLResponseDTO.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Models.DTOs
+{
+    public class WeeklyPNLResponseDTO
+    {
+        public DateOnly WeekStartDate { get; set; }
+        public DateOnly WeekEndDate { get; set; }
+        public float WeeklyPNL { get; set; }
+        public int ActualDays { get; set; }
+        public DateTime LastUpdated { get; set; }
+    }
+}


### PR DESCRIPTION
Introduced a new `GetWeeklyPNL` API endpoint in `AccountController` to fetch weekly Profit and Loss (PNL) data.

 Updated the `IBinanceService` interface and implemented `GetWeeklyPNLAsync` in both `BinanceService` and `BinanceMockService`, including logic to aggregate daily PNL into weekly data and handle month boundaries.

Added a new DTO `WeeklyPNLResponseDTO` to represent weekly PNL data.

Wrote comprehensive unit tests in `BinanceServiceTests` to validate the new functionality.

Made minor adjustments to `BinanceService` and improved error handling and validation across the codebase.